### PR TITLE
Add button-{primary, secondary, anchor}-active-color controls to demo/style picker site

### DIFF
--- a/demo/examples/common.js
+++ b/demo/examples/common.js
@@ -78,6 +78,10 @@ export const properties = [
         type: 'color',
       },
       {
+        name: 'button-primary-color-active',
+        type: 'color',
+      },
+      {
         name: 'button-primary-border',
         type: 'border',
       },
@@ -103,6 +107,10 @@ export const properties = [
         type: 'color',
       },
       {
+        name: 'button-secondary-color-active',
+        type: 'color',
+      },
+      {
         name: 'button-secondary-border',
         type: 'border',
       },
@@ -125,6 +133,10 @@ export const properties = [
       },
       {
         name: 'button-anchor-color-hover',
+        type: 'color',
+      },
+      {
+        name: 'button-anchor-color-active',
         type: 'color',
       },
       {


### PR DESCRIPTION
The current demo website doesn't have a setting/color picker field for the `button-primary-active-color`, `button-secondary-active-color`, and `button-anchor-active-color` css variables, leading it to be very confusing for why there's no way to style a button's color when pressed. This fixes that issue with a few lines changed in one of the demo site's config files, which adds each input field to the correct spot and pre-populates with the correct colors per builtin theme. I hope this will save a future person a good amount of debugging time. Thanks!

Note: I don't know this project's preferred build/release process so I left the build for the demo unchanged. Please let me know if you'd like me to re-build it before a merge. 