### PR TITLE
Fixed #69

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,8 +146,10 @@ Checkout this example live on the [storyboard](https://caferati.me/demo/react-aw
       <AwesomeButtonProgress
         cssModule={AwesomeButtonStyles}
         type="primary"
-        onPress={next => {
+        onPress={(ref, next) => {
           // do a sync/async task then call `next()`
+          console.log("Async operations 🔄");
+          next();
         }}
       >
         Button


### PR DESCRIPTION
### `next` is actually the second parameter of the `onPress` callback function !

As pointed out in the [issue 69](https://github.com/rcaferati/react-awesome-button/issues/69), when we try to use the `next` function in the `onPress` callback we get an error : `next is not a function`. Because the first argument of the `onPress` callback function is actually a `ref` !

As we can at the line 160 of the file `components/AwesomeButtonProgress/index.js` :

```javascript
action(this.content, this.endLoading.bind(this));
```

The `next` function is actually the second argument ! As it would be a breaking change to swap the argument order I propose to update the documentation which is misleading.