### PR TITLE
fix: restore theme line-height parity

### DIFF
--- a/src/styles/themes/theme-amber/config/structure.scss
+++ b/src/styles/themes/theme-amber/config/structure.scss
@@ -1,5 +1,5 @@
 $button-default-border-radius: 2px;
-$button-default-line-height: 28px;
+$button-default-line-height: 24px;
 $button-horizontal-padding: 20px;
 $button-raise-level: 2px;
 $transform-speed: 0.175s;

--- a/src/styles/themes/theme-bruce/config/structure.scss
+++ b/src/styles/themes/theme-bruce/config/structure.scss
@@ -1,5 +1,6 @@
 $button-default-height: 55px;
 $button-default-border-radius: 6px;
+$button-default-line-height: 24px;
 $button-horizontal-padding: 20px;
 $button-raise-level: 6px;
 $transform-speed: 0.185s;

--- a/src/styles/themes/theme-c137/config/structure.scss
+++ b/src/styles/themes/theme-c137/config/structure.scss
@@ -1,6 +1,6 @@
 $button-default-height: 48px;
 $button-default-border-radius: 6px;
-$button-default-line-height: 28px;
+$button-default-line-height: 24px;
 $button-horizontal-padding: 20px;
 $button-raise-level: 5px;
 $transform-speed: 0.185s;

--- a/src/styles/themes/theme-eric/config/structure.scss
+++ b/src/styles/themes/theme-eric/config/structure.scss
@@ -1,6 +1,6 @@
 $button-default-height: 48px;
 $button-default-border-radius: 6px;
-$button-default-line-height: 28px;
+$button-default-line-height: 24px;
 $button-horizontal-padding: 20px;
 $button-raise-level: 5px;
 $transform-speed: 0.185s;

--- a/src/styles/themes/theme-rickiest/config/structure.scss
+++ b/src/styles/themes/theme-rickiest/config/structure.scss
@@ -1,6 +1,6 @@
 $button-default-height: 48px;
 $button-default-border-radius: 6px;
-$button-default-line-height: 28px;
+$button-default-line-height: 24px;
 $button-horizontal-padding: 20px;
 $button-raise-level: 5px;
 $transform-speed: 0.185s;


### PR DESCRIPTION
## Summary
- restore the React theme line-height overrides to the Vue-parity 24px value for amber, c137, eric, and rickiest
- add the missing explicit 24px line-height override for bruce
- correct the previous theme-line-height patch, which introduced the wrong 28px value for these themes

## Testing
- npm run build